### PR TITLE
local dynamo db change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>dynamok</groupId>
     <artifactId>kafka-connect-dynamodb</artifactId>
     <packaging>jar</packaging>
-    <version>0.3.0-letgo</version>
+    <version>0.3.0-letgo-SNAPSHOT</version>
     <name>kafka-connect-dynamodb</name>
     <description>
         A Kafka Connect DynamoDB connector for copying data between DynamoDB and Kafka.

--- a/src/main/java/dynamok/sink/ConnectorConfig.java
+++ b/src/main/java/dynamok/sink/ConnectorConfig.java
@@ -43,6 +43,7 @@ class ConnectorConfig extends AbstractConfig {
         static final String TOP_VALUE_ATTRIBUTE = "top.value.attribute";
         static final String MAX_RETRIES = "max.retries";
         static final String RETRY_BACKOFF_MS = "retry.backoff.ms";
+        static final String ENDPOINT_URL = "endpoint-url";
     }
 
     static final ConfigDef CONFIG_DEF = new ConfigDef()
@@ -80,7 +81,8 @@ class ConnectorConfig extends AbstractConfig {
             .define(Keys.MAX_RETRIES, ConfigDef.Type.INT, 10,
                     ConfigDef.Importance.MEDIUM, "The maximum number of times to retry on errors before failing the task.")
             .define(Keys.RETRY_BACKOFF_MS, ConfigDef.Type.INT, 3000,
-                    ConfigDef.Importance.MEDIUM, "The time in milliseconds to wait following an error before a retry attempt is made.");
+                    ConfigDef.Importance.MEDIUM, "The time in milliseconds to wait following an error before a retry attempt is made.")
+            .define(Keys.ENDPOINT_URL, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,ConfigDef.Importance.LOW,"End point url" );
 
     final Regions region;
     final Password accessKeyId;
@@ -94,6 +96,7 @@ class ConnectorConfig extends AbstractConfig {
     final String topValueAttribute;
     final int maxRetries;
     final int retryBackoffMs;
+    final String endPointUrl;
 
     ConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
@@ -109,6 +112,8 @@ class ConnectorConfig extends AbstractConfig {
         topValueAttribute = getString(Keys.TOP_VALUE_ATTRIBUTE);
         maxRetries = getInt(Keys.MAX_RETRIES);
         retryBackoffMs = getInt(Keys.RETRY_BACKOFF_MS);
+        endPointUrl = getString(Keys.ENDPOINT_URL);
+        
     }
 
     ConnectorConfig(Map<String, String> props) {

--- a/src/main/java/dynamok/sink/DynamoDbSinkTask.java
+++ b/src/main/java/dynamok/sink/DynamoDbSinkTask.java
@@ -27,6 +27,8 @@ import com.amazonaws.services.dynamodbv2.model.LimitExceededException;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.dynamodbv2.model.PutRequest;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
+import com.amazonaws.util.StringUtils;
+
 import dynamok.Version;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -86,6 +88,10 @@ public class DynamoDbSinkTask extends SinkTask {
         }
 
         client.configureRegion(config.region);
+        if(!StringUtils.isNullOrEmpty(config.endPointUrl)) {
+        	client.setEndpoint(config.endPointUrl);
+        	client.setSignerRegionOverride("local");
+        }
         remainingRetries = config.maxRetries;
     }
 


### PR DESCRIPTION
Cherry picked a commit from another existing fork of the kafka-connect-dynamodb project, in order to be able to specify an endpoint for the dynamoDB client